### PR TITLE
feat: add keybind to open card wallet fixing #160

### DIFF
--- a/src/generated/resources/.cache/a582491eaf5004e1c795d4ef0ed07b246b6fc393
+++ b/src/generated/resources/.cache/a582491eaf5004e1c795d4ef0ed07b246b6fc393
@@ -1,2 +1,2 @@
-// 1.21.1	2025-04-30T11:29:13.833456	Languages: en_us for mod: tempad
-064d376bfa65b14752ae27e80d43188a75fb37bb assets/tempad/lang/en_us.json
+// 1.21.1	2025-10-19T16:51:28.778536	Languages: en_us for mod: tempad
+122fc3d0f5a1be817c0cb2021ef50774fad70ca1 assets/tempad/lang/en_us.json

--- a/src/generated/resources/assets/tempad/lang/en_us.json
+++ b/src/generated/resources/assets/tempad/lang/en_us.json
@@ -158,6 +158,7 @@
   "key.tempad": "",
   "key.tempad.macro": "Use Tempad Macro",
   "key.tempad.new_location": "Open Tempad New Location App",
+  "key.tempad.open_wallet": "Open Location Card Wallet",
   "key.tempad.shortcut": "Open Tempad Screen",
   "key.tempad.travel_timeline": "Open Tempad Travel Timeline App",
   "upgrade.tempad.knowledge_repository": "View Knowledge Respository",

--- a/src/main/kotlin/earth/terrarium/tempad/client/ModKeybinds.kt
+++ b/src/main/kotlin/earth/terrarium/tempad/client/ModKeybinds.kt
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.platform.InputConstants
 import earth.terrarium.tempad.Tempad
 import earth.terrarium.tempad.common.network.c2s.OpenAppPacket
 import earth.terrarium.tempad.common.network.c2s.OpenTempadPacket
+import earth.terrarium.tempad.common.network.c2s.OpenWalletPacket
 import earth.terrarium.tempad.common.network.c2s.UseMacroPacket
 import earth.terrarium.tempad.common.registries.ModApps
 import earth.terrarium.tempad.common.utils.sendToServer
@@ -47,6 +48,13 @@ object ModKeybinds {
         "category.tempad"
     )
 
+    val openCardWallet: KeyMapping = KeyMapping(
+        "key.tempad.open_wallet",
+        InputConstants.Type.KEYSYM,
+        InputConstants.UNKNOWN.value,
+        "category.tempad"
+    )
+
     @SubscribeEvent @JvmStatic
     fun init(event: FMLClientSetupEvent) {
         NeoForge.EVENT_BUS.addListener(::onClientTick);
@@ -58,6 +66,7 @@ object ModKeybinds {
         event.register(useMacro)
         event.register(newLocation)
         event.register(travelTimeline)
+        event.register(openCardWallet)
     }
 
     private fun onClientTick(event: ClientTickEvent.Post) {
@@ -72,6 +81,9 @@ object ModKeybinds {
         }
         while (travelTimeline.consumeClick()) {
             OpenAppPacket(ModApps.timeline).sendToServer()
+        }
+        while(openCardWallet.consumeClick()) {
+            OpenWalletPacket().sendToServer()
         }
     }
 }

--- a/src/main/kotlin/earth/terrarium/tempad/common/network/c2s/OpenWalletPacket.kt
+++ b/src/main/kotlin/earth/terrarium/tempad/common/network/c2s/OpenWalletPacket.kt
@@ -1,0 +1,39 @@
+package earth.terrarium.tempad.common.network.c2s
+
+import com.teamresourceful.bytecodecs.base.ByteCodec
+import com.teamresourceful.resourcefullib.common.bytecodecs.ExtraByteCodecs
+import com.teamresourceful.resourcefullib.common.network.Packet
+import com.teamresourceful.resourcefullib.common.network.base.PacketType
+import earth.terrarium.tempad.api.app.AppRegistry
+import earth.terrarium.tempad.api.context.ContextRegistry
+import earth.terrarium.tempad.api.macro.MacroRegistry
+import earth.terrarium.tempad.common.items.items
+import earth.terrarium.tempad.common.network.ServerPacketCompanion
+import earth.terrarium.tempad.common.registries.ModApps
+import earth.terrarium.tempad.common.registries.ModItems
+import earth.terrarium.tempad.common.registries.defaultApp
+import earth.terrarium.tempad.common.registries.defaultMacro
+import earth.terrarium.tempad.common.registries.walletContents
+import earth.terrarium.tempad.tempadId
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.world.entity.player.Player
+
+class OpenWalletPacket: Packet<OpenWalletPacket> {
+
+
+    companion object: ServerPacketCompanion<OpenWalletPacket> {
+        override val id = "open_wallet".tempadId
+        override val byteCodec: ByteCodec<OpenWalletPacket> = ByteCodec.unit (::OpenWalletPacket)
+        override fun onReceive(
+            packet: OpenWalletPacket,
+            player: Player
+        ) {
+            val ctx = ContextRegistry.locate(player) { it.`is`(ModItems.cardWallet) } ?: return
+            player.openMenu(ctx.stack.items)
+
+        }
+    }
+
+    override fun type(): PacketType<OpenWalletPacket> = Companion
+}

--- a/src/main/kotlin/earth/terrarium/tempad/common/registries/ModNetworking.kt
+++ b/src/main/kotlin/earth/terrarium/tempad/common/registries/ModNetworking.kt
@@ -15,6 +15,7 @@ object ModNetworking {
         channel.register(RedirectAppPacket.type)
         channel.register(OpenAppPacket)
         channel.register(OpenTempadPacket)
+        channel.register(OpenWalletPacket)
         channel.register(OpenTimedoorPacket.type)
         channel.register(SaveSettingsPacket.type)
         channel.register(SetFavoritePacket.type)

--- a/src/main/kotlin/earth/terrarium/tempad/data/client/ModLang.kt
+++ b/src/main/kotlin/earth/terrarium/tempad/data/client/ModLang.kt
@@ -1133,6 +1133,7 @@ class ModLang(output: PackOutput) : LanguageProvider(output, Tempad.MOD_ID, "en_
             it.addSub("macro", "Use Tempad Macro")
             it.addSub("new_location", "Open Tempad New Location App")
             it.addSub("travel_timeline", "Open Tempad Travel Timeline App")
+            it.addSub("open_wallet","Open Location Card Wallet")
         }
     }
 


### PR DESCRIPTION
This change adds a keybind that opens the first location card wallet it finds, If there are multiple, it only opens one, if there is none, nothing happens.